### PR TITLE
Added backward compatibility for OTel

### DIFF
--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <packaging>pom</packaging>
     <groupId>dev.vality.woody</groupId>
     <artifactId>woody</artifactId>
-    <version>2.0.8</version>
+    <version>2.0.9</version>
 
     <name>Woody Java</name>
     <description>Java implementation for Woody spec</description>

--- a/woody-api/pom.xml
+++ b/woody-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/woody-api/pom.xml
+++ b/woody-api/pom.xml
@@ -23,6 +23,7 @@
             <artifactId>commons-pool2</artifactId>
             <version>2.11.1</version>
         </dependency>
+        <!--Opentelemetry libs-->
         <dependency>
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-api</artifactId>
@@ -37,6 +38,12 @@
             <groupId>io.opentelemetry</groupId>
             <artifactId>opentelemetry-exporter-otlp</artifactId>
             <version>1.41.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-semconv</artifactId>
+            <version>1.30.1-alpha</version>
+            <scope>runtime</scope>
         </dependency>
         <!--Test libs-->
         <dependency>

--- a/woody-thrift/pom.xml
+++ b/woody-thrift/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.8</version>
+        <version>2.0.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/woody-thrift/src/main/java/dev/vality/woody/thrift/impl/http/transport/THttpHeader.java
+++ b/woody-thrift/src/main/java/dev/vality/woody/thrift/impl/http/transport/THttpHeader.java
@@ -1,23 +1,28 @@
 package dev.vality.woody.thrift.impl.http.transport;
 
 public enum THttpHeader {
-    TRACE_ID("woody.trace-id"),
-    SPAN_ID("woody.span-id"),
-    TRACE_PARENT("traceparent"),
-    PARENT_ID("woody.parent-id"),
-    DEADLINE("woody.deadline"),
-    ERROR_CLASS("woody.error-class"),
-    ERROR_REASON("woody.error-reason"),
-    META("woody.meta.");
+    TRACE_ID("woody.trace-id", false),
+    SPAN_ID("woody.span-id", false),
+    TRACE_PARENT("traceparent", true),
+    PARENT_ID("woody.parent-id", false),
+    DEADLINE("woody.deadline", false),
+    ERROR_CLASS("woody.error-class", false),
+    ERROR_REASON("woody.error-reason", false),
+    META("woody.meta.", false);
 
-    private String key;
+    private final String key;
+    private final boolean optional;
 
-    THttpHeader(String key) {
+    THttpHeader(String key, boolean optional) {
         this.key = key;
+        this.optional = optional;
     }
 
     public String getKey() {
         return key;
     }
 
+    public boolean isOptional() {
+        return optional;
+    }
 }

--- a/woody-thrift/src/test/java/dev/vality/woody/thrift/impl/http/TestClientAndServerHttpHeaders.java
+++ b/woody-thrift/src/test/java/dev/vality/woody/thrift/impl/http/TestClientAndServerHttpHeaders.java
@@ -77,7 +77,7 @@ public class TestClientAndServerHttpHeaders extends AbstractTest {
             protected void doPost(HttpServletRequest request, HttpServletResponse response)
                     throws ServletException, IOException {
                 for (THttpHeader tHttpHeader : Arrays.asList(THttpHeader.SPAN_ID, THttpHeader.TRACE_ID,
-                        THttpHeader.PARENT_ID, THttpHeader.TRACE_PARENT)) {
+                        THttpHeader.PARENT_ID)) {
                     assertNotNull(request.getHeader(tHttpHeader.getKey()));
                 }
                 writeResultMessage(request, response);

--- a/woody-thrift/src/test/java/dev/vality/woody/thrift/impl/http/TestClientAndServerHttpHeaders.java
+++ b/woody-thrift/src/test/java/dev/vality/woody/thrift/impl/http/TestClientAndServerHttpHeaders.java
@@ -167,7 +167,6 @@ public class TestClientAndServerHttpHeaders extends AbstractTest {
                     httpRequest.removeHeader(httpRequest.getFirstHeader(THttpHeader.SPAN_ID.getKey()));
                     httpRequest.removeHeader(httpRequest.getFirstHeader(THttpHeader.TRACE_ID.getKey()));
                     httpRequest.removeHeader(httpRequest.getFirstHeader(THttpHeader.PARENT_ID.getKey()));
-                    httpRequest.removeHeader(httpRequest.getFirstHeader(THttpHeader.TRACE_PARENT.getKey()));
                 }).build();
 
         OwnerServiceSrv.Iface client =
@@ -182,6 +181,69 @@ public class TestClientAndServerHttpHeaders extends AbstractTest {
             assertEquals(WErrorSource.INTERNAL, errorDefinition.getErrorSource());
             assertEquals("Bad Request", errorDefinition.getErrorMessage());
         }
+    }
+
+    @Test
+    public void testTraceDataOtel() throws TException {
+        addServlet(testServlet, servletContextPath);
+        CloseableHttpClient httpClient =
+                HttpClients.custom().addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) ->
+                                httpRequest.setHeader(
+                                        THttpHeader.TRACE_PARENT.getKey(),
+                                        "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01"
+                                )
+                        )
+                        .addResponseInterceptorLast((httpResponse, entityDetails, httpContext) ->
+                                assertEquals(
+                                        "00-80e1afed08e019fc1110464cfa66635c-7a085853722dc6d2-01",
+                                        httpResponse.getHeader(THttpHeader.TRACE_PARENT.getKey()).getValue()
+                                )
+                        )
+                        .build();
+
+        OwnerServiceSrv.Iface client = createThriftRPCClient(
+                OwnerServiceSrv.Iface.class, getUrlString(servletContextPath), httpClient
+        );
+        client.getIntValue();
+    }
+
+    @Test
+    public void testWhenTraceDataOtelIsEmpty() throws TException {
+        addServlet(testServlet, servletContextPath);
+        CloseableHttpClient httpClient =
+                HttpClients.custom().addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) ->
+                                assertNull(httpRequest.getHeader(THttpHeader.TRACE_PARENT.getKey()))
+                        )
+                        .addResponseInterceptorLast((httpResponse, entityDetails, httpContext) ->
+                                assertNull(httpResponse.getHeader(THttpHeader.TRACE_PARENT.getKey()))
+                        )
+                        .build();
+
+        OwnerServiceSrv.Iface client = createThriftRPCClient(
+                OwnerServiceSrv.Iface.class, getUrlString(servletContextPath), httpClient
+        );
+        client.getIntValue();
+    }
+
+    @Test
+    public void testWhenTraceDataOtelIsInvalid() throws TException {
+        addServlet(testServlet, servletContextPath);
+        CloseableHttpClient httpClient =
+                HttpClients.custom().addRequestInterceptorFirst((httpRequest, entityDetails, httpContext) ->
+                                httpRequest.setHeader(
+                                        THttpHeader.TRACE_PARENT.getKey(),
+                                        "invalid"
+                                )
+                        )
+                        .addResponseInterceptorLast((httpResponse, entityDetails, httpContext) ->
+                                assertNull(httpResponse.getHeader(THttpHeader.TRACE_PARENT.getKey()))
+                        )
+                        .build();
+
+        OwnerServiceSrv.Iface client = createThriftRPCClient(
+                OwnerServiceSrv.Iface.class, getUrlString(servletContextPath), httpClient
+        );
+        client.getIntValue();
     }
 
 }


### PR DESCRIPTION
Проблема:
TECH-48 - Сейчас, при интеграции otel в джава-сервисы, есть проблема, при которой ломается обратная совместимость. Например, service1 обращается в service2. Если service2 добавит к себе otel, то взаимодействие этих сервисов сломается, поскольку service2 будет ожидать otel-заголовки и при их отсутствии отвечать кодом 400.

Решение:
Сделать OTel опциональным.