### PR TITLE
second put mdc after filling metadata

### DIFF
--- a/libthrift/pom.xml
+++ b/libthrift/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.13</version>
+        <version>2.0.14</version>
     </parent>
 
     <artifactId>libthrift</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <groupId>dev.vality.woody</groupId>
     <artifactId>woody</artifactId>
-    <version>2.0.13</version>
+    <version>2.0.14</version>
 
     <name>Woody Java</name>
     <description>Java implementation for Woody spec</description>

--- a/woody-api/pom.xml
+++ b/woody-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.13</version>
+        <version>2.0.14</version>
     </parent>
 
     <artifactId>woody-api</artifactId>

--- a/woody-api/src/main/java/dev/vality/woody/api/proxy/tracer/TargetCallTracer.java
+++ b/woody-api/src/main/java/dev/vality/woody/api/proxy/tracer/TargetCallTracer.java
@@ -1,5 +1,6 @@
 package dev.vality.woody.api.proxy.tracer;
 
+import dev.vality.woody.api.MDCUtils;
 import dev.vality.woody.api.event.ClientEventType;
 import dev.vality.woody.api.event.ServiceEventType;
 import dev.vality.woody.api.proxy.InstanceMethodCaller;
@@ -7,6 +8,7 @@ import dev.vality.woody.api.trace.ContextSpan;
 import dev.vality.woody.api.trace.ContextUtils;
 import dev.vality.woody.api.trace.Metadata;
 import dev.vality.woody.api.trace.MetadataProperties;
+import dev.vality.woody.api.trace.TraceData;
 import dev.vality.woody.api.trace.context.TraceContext;
 
 public class TargetCallTracer implements MethodCallTracer {
@@ -62,6 +64,11 @@ public class TargetCallTracer implements MethodCallTracer {
         metadata.putValue(MetadataProperties.INSTANCE_METHOD_CALLER, caller);
         metadata.putValue(MetadataProperties.EVENT_TYPE,
                 isClient ? ClientEventType.CALL_SERVICE : ServiceEventType.CALL_HANDLER);
+        TraceData currentTraceData = TraceContext.getCurrentTraceData();
+        ContextSpan activeSpan = currentTraceData != null ? currentTraceData.getActiveSpan() : null;
+        if (currentTraceData != null && activeSpan != null) {
+            MDCUtils.putTraceData(currentTraceData, activeSpan);
+        }
     }
 
     private void setAfterCall(Metadata metadata, Object[] args, InstanceMethodCaller caller, Object result,

--- a/woody-api/src/test/java/dev/vality/woody/api/proxy/tracer/TargetCallTracerMdcTest.java
+++ b/woody-api/src/test/java/dev/vality/woody/api/proxy/tracer/TargetCallTracerMdcTest.java
@@ -1,0 +1,81 @@
+package dev.vality.woody.api.proxy.tracer;
+
+import dev.vality.woody.api.MDCUtils;
+import dev.vality.woody.api.event.ServiceEventType;
+import dev.vality.woody.api.proxy.InstanceMethodCaller;
+import dev.vality.woody.api.trace.ContextSpan;
+import dev.vality.woody.api.trace.MetadataProperties;
+import dev.vality.woody.api.trace.TraceData;
+import dev.vality.woody.api.trace.context.TraceContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.MDC;
+
+import java.lang.reflect.Method;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class TargetCallTracerMdcTest {
+
+    private TraceData originalTraceData;
+    private TraceContext traceContext;
+
+    @Before
+    public void setUp() {
+        originalTraceData = TraceContext.getCurrentTraceData();
+        TraceContext.setCurrentTraceData(new TraceData());
+        MDC.clear();
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            if (traceContext != null) {
+                traceContext.destroy(false);
+            }
+        } finally {
+            TraceContext.setCurrentTraceData(originalTraceData);
+            MDCUtils.removeTraceData();
+        }
+    }
+
+    @Test
+    public void shouldPopulateRpcFieldsAfterTargetCallTracer() throws Exception {
+        TraceData traceData = TraceContext.getCurrentTraceData();
+        ContextSpan serviceSpan = traceData.getServiceSpan();
+        serviceSpan.getSpan().setTraceId("trace-1");
+        serviceSpan.getSpan().setParentId("parent-1");
+        serviceSpan.getSpan().setId("span-1");
+        serviceSpan.getMetadata().putValue(MetadataProperties.CALL_NAME, "ServerCall");
+
+        traceContext = TraceContext.forService();
+        traceContext.init();
+
+        assertNull("RPC service field must not be populated before TargetCallTracer",
+                MDC.get(MDCUtils.TRACE_RPC_SERVER_PREFIX + "service"));
+
+        InstanceMethodCaller caller = createCaller("sampleHandler");
+        TargetCallTracer.forServer().beforeCall(new Object[0], caller);
+
+        assertEquals("SampleService", MDC.get(MDCUtils.TRACE_RPC_SERVER_PREFIX + "service"));
+        assertEquals("ServerCall", MDC.get(MDCUtils.TRACE_RPC_SERVER_PREFIX + "function"));
+        assertEquals("call handler", MDC.get(MDCUtils.TRACE_RPC_SERVER_PREFIX + "event"));
+    }
+
+    private InstanceMethodCaller createCaller(String methodName) throws Exception {
+        Method method = SampleService.class.getDeclaredMethod(methodName);
+        return new InstanceMethodCaller(method) {
+            @Override
+            public Object call(Object source, Object[] args) {
+                return null;
+            }
+        };
+    }
+
+    private static class SampleService {
+        public void sampleHandler() {
+        }
+    }
+}

--- a/woody-thrift/pom.xml
+++ b/woody-thrift/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>woody</artifactId>
         <groupId>dev.vality.woody</groupId>
-        <version>2.0.13</version>
+        <version>2.0.14</version>
     </parent>
 
     <artifactId>woody-thrift</artifactId>


### PR DESCRIPTION
⛬  Findings

   Причина

   MDC заполняется в TraceContext.init() сразу после new ContextTracer(... TargetCallTracer ...).
   TargetCallTracer.beforeCall() (который заносит callName, event и т.п. в метаданные сервера) выполняется позже, уже после MDCUtils.putTraceData().
    Поэтому при первом логировании в перехватчике ContextInterceptor MDC ещё содержит только идентификаторы, а расширенные RPC‑атрибуты появляются
   позднее — уже после отработки TargetCallTracer и повторного вызова MDCUtils.putTraceData (либо при следующем логирующем событии).

   Как убедиться

   Поставьте логирование (или breakpoint) сразу после MDCUtils.putTraceData(traceData, traceData.getActiveSpan()) в TraceContext.init(): вы увидите,
    что traceData.getServiceSpan().getMetadata() ещё пустой. После входа в TargetCallTracer.beforeCall() значения появляются, и следующим вызовом
   MDCUtils.putTraceData они попадут в MDC.

   Возможные решения
   1. Перенести публикацию MDC: вызывайте MDCUtils.putTraceData после того, как TargetCallTracer.beforeCall() заполнил метаданные (например, из
      самого TargetCallTracer или отдельного интерсептора, стоящего после него).
   2. Отложить логирование: если нужно логировать именно в ContextInterceptor, добавьте одноразовый повторный вызов MDCUtils.putTraceData уже после
      цепочки MethodCallTracer (например, в TargetCallTracer по окончании beforeCall).
   3. Добавить флаг и повторную публикацию в MDCUtils/TraceContext, чтобы при первом расширении метаданных перезаполнить MDC.

   Любое из этих изменений гарантирует, что к моменту создания логов все RPC‑поля уже будут присутствовать в MDC.

